### PR TITLE
fragmentURI methods for working with single page apps

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -360,8 +360,9 @@ p.build = function() {
 };
 
 p.toString = function() {
-    // return this.build()._string;
-    return this._string;
+    return this.isFragmentURI() ?
+        (new URI(this.parentURI)).fragment(this._string).toString() :
+        this._string;
 };
 p.valueOf = function() {
     return this.toString();
@@ -893,6 +894,28 @@ p.relativeTo = function(base) {
     relative.build();
     return relative;
 };
+
+p.fragmentURI = function() {
+    if (this.isFragmentURI()) {
+        throw new TypeError("cannot nest fragmentURIs");
+    }
+
+    var frag = new URI(this.fragment());
+    frag.parentURI = this;
+    return frag;
+}
+
+p.isFragmentURI = function() {
+    return !!this.parentURI;
+}
+
+p.reassemble = function() {
+    if (!this.isFragmentURI()) {
+        throw new TypeError("can only reassemble fragment URIs");
+    }
+
+    return this.parentURI.fragment(this._string);
+}
 
 window.URI = URI;
 

--- a/test/test.js
+++ b/test/test.js
@@ -415,6 +415,38 @@ test("removeQuery", function() {
     equal(u.query(), 'foo=baz&foo=bam&bar=3', 'removing object');
 });
 
+module("fragmentURI");
+test("fragmentURI retrieval", function() {
+    var u = new URI("http://www.example.org/?userid=1#/single/page/app?page=5");
+    equal(u.fragmentURI().path(), "/single/page/app", "retrieve path from fragmentURI");
+    equal(u.fragmentURI().query(), "page=5", "retrieve query from fragmentURI");
+    raises(function() {
+        u.fragmentURI().fragmentURI();
+    }, TypeError, "nested calls to fragmentURI raises error");
+});
+test("isFragmentURI", function() {
+    var u = new URI("http://www.example.org/?userid=1#/single/page/app?page=5");
+    ok(u.fragmentURI().isFragmentURI(), "returns true when in fragmentURI");
+    ok(!u.isFragmentURI(), "returns false when not in fragmentURI");
+});
+test("fragmentURI mutation", function() {
+    var u = new URI("http://www.example.org/?userid=1#/single/page/app?page=5");
+    equal(u.fragmentURI().path("/otherpath")+"", "http://www.example.org/?userid=1#/otherpath?page=5", "string of modified fragmentURI returns reassembled full URL");
+    equal(u+"", "http://www.example.org/?userid=1#/single/page/app?page=5", "modifying a fragmentURI without calling reassemble, does not modify the original URI");
+    u.fragmentURI().path("/foo").addSearch("num", 6).reassemble();
+    equal(u+"", "http://www.example.org/?userid=1#/foo?page=5&num=6", "reassemble modifies the original URL");
+
+    u = new URI("http://www.example.org/?userid=1#/single/page/app?page=5");
+    var frag = u.fragmentURI();
+    frag.path("/foo");
+    u.port("8080");
+    frag.reassemble();
+    equal(u+"", "http://www.example.org:8080/?userid=1#/foo?page=5", "reassemble references the parent URI, not a copy");
+
+    raises(function() {
+        u.reassemble();
+    }, TypeError, "calling reassemble when not in a fragmentURI raises error");
+});
 
 module("normalizing");
 test("normalize", function() {


### PR DESCRIPTION
This library looks really good except for the fact that it didn't offer much utility in working with single page applications (e.g. using [Backbone Router](http://documentcloud.github.com/backbone/#Router) or [Sammy.js](http://sammyjs.org/)).  You can work around this by extracting the `fragment` from the URI, making a new URI from that, modifying it, and plugging it back into the `fragment` of the original URI; or you could use the helper methods I added in this pull request.

Tests are included, but documentation isn't.  If the code meets your standards, I will be happy to update the pull request with changes to the documentation files as well.
