### PR TITLE
Helper methods for using URI.js against servers not understanding UTF-8 encoded URIs

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -116,6 +116,8 @@
                 
                 <li><a href="#static-commonPath">URI.commonPath()</a></li>
                 <li><a href="#static-withinString">URI.withinString()</a></li>
+    		<li><a href="#static-iso8859">URI.iso8859()</a></li>
+    		<li><a href="#static-unicode">URI.unicode()</a></li>
             </ul>
         </li>
     </ul>
@@ -756,6 +758,20 @@ var escapeHtml = function(string) {
             + escapeHtml(url.<a href="#readable">readable</a>()) + '&lt;/a&gt;';
     });
 </pre>
+    
+    <h3 id="static-iso8859">URI.iso8859()</h3>
+    <p>URI.iso8859() tells URI.js to use the older escape/unescape methods, for backwards compatibility with older platforms.</p>
+    <pre class="prettyprint lang-js">URI.iso8859();
+
+var uri = new URI("http://example.org/foo/æ.html");
+// http://example.org/foo/%E6.html</pre>
+    
+    <h3 id="static-unicode">URI.unicode()</h3>
+    <p>URI.unicode() restores the default unicode-encoded URLs.</p>
+    <pre class="prettyprint lang-js">URI.unicode();
+
+var uri = new URI("http://example.org/foo/æ.html");
+// http://example.org/foo/%C3%A6.html</pre>
     
     </div>
 </body>

--- a/src/URI.js
+++ b/src/URI.js
@@ -65,8 +65,18 @@ var URI = function(url, base) {
         }
         
         return this;
-    },
-    p = URI.prototype;
+    };
+var p = URI.prototype;
+
+URI.iso8859 = function() {
+	URI.encode = escape;
+	URI.decode = unescape;
+}
+
+URI.unicode = function() {
+	URI.encode = encodeURIComponent;
+	URI.decode = decodeURIComponent;
+}
 
 // static properties
 URI.idn_expression = /[^a-z0-9\.-]/i;
@@ -122,10 +132,10 @@ URI.characters = {
     }
 };
 URI.encodeQuery = function(string) {
-    return encodeURIComponent(string + "").replace(/%20/g, '+');
+    return URI.encode(string + "").replace(/%20/g, '+');
 };
 URI.decodeQuery = function(string) {
-    return decodeURIComponent((string + "").replace(/\+/g, '%20'));
+    return URI.decode((string + "").replace(/\+/g, '%20'));
 };
 URI.recodePath = function(string) {
     var segments = (string + "").split('/');


### PR DESCRIPTION
Hello,

This patch adds two new static functions - URI.iso8859 and URI.unicode - that replace the URI.encode and URI.decode refs with the old escape/unescape functions - and restores the default.
I have also modified the en/de-codeQuery methods to reference URI.en/de-code in order for the switching of modes to have the least possible impact (and avoiding redefining the methods).

I have also added the two new static methods to the documentation.

  // Cheers, Morten
