### PR TITLE
Add missing `var` declarations

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -212,7 +212,7 @@ URI.parse = function(string) {
 };
 URI.parseHost = function(string, parts) {
     // extract host:port
-    var pos = string.indexOf('/');
+    var pos = string.indexOf('/'), t;
     if (pos === -1) {
         pos = string.length;
     }
@@ -245,7 +245,8 @@ URI.parseHost = function(string, parts) {
 URI.parseAuthority = function(string, parts) {
     // extract username:password
     var pos = string.indexOf('@'),
-        firstSlash = string.indexOf('/');
+        firstSlash = string.indexOf('/'),
+        t;
 
     // authority@ must come before /path
     if (pos > -1 && (firstSlash === -1 || pos < firstSlash)) {
@@ -889,7 +890,7 @@ p.suffix = function(v, build) {
 
         var filename = this.filename(),
             pos = filename.lastIndexOf('.'),
-            s;
+            s, res;
 
         if (pos === -1) {
             return "";


### PR DESCRIPTION
In my current project at work, we are using `t` as our global "translate" function.  You can imagine my shock when I realized that calling `new URI()` caused half of my unit tests to break due to `window.t` not being a function!

This patch fixes the missing var statements.  I didn't add any tests, but this didn't break any existing tests either.
