### PR TITLE
Handle scheme relative URIs

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -205,6 +205,13 @@ URI.parse = function(string) {
 
         // extract "user:pass@host:port"
         string = URI.parseAuthority(string, parts);
+    } else if (string.slice(0, 2) === '//') {
+        // Scheme relative URI like //example.com/file.html
+        parts.protocol = null;
+        string = string.substring(2);
+
+        // extract "user:pass@host:port"
+        string = URI.parseAuthority(string, parts);
     }
 
     // what's left must be the path
@@ -305,11 +312,15 @@ URI.parseQuery = function(string) {
 URI.build = function(parts) {
     var t = '';
 
+    var authority = URI.buildAuthority(parts) || '';
+
     if (typeof parts.protocol === "string" && parts.protocol.length) {
         t += parts.protocol + "://";
+    } else if (authority) {
+        t += '//';
     }
 
-    t += (URI.buildAuthority(parts) || '');
+    t += authority
 
     if (typeof parts.path === "string") {
         if (parts.path[0] !== '/' && typeof parts.hostname === "string") {

--- a/test/test.js
+++ b/test/test.js
@@ -83,11 +83,11 @@ test("protocol", function() {
 
     u.protocol('');
     equal(u.protocol(), "", "missing protocol");
-    equal(u+"", "example.org/foo.html", "no-scheme url");
+    equal(u+"", "//example.org/foo.html", "no-scheme url");
 
     u.protocol(null);
     equal(u.protocol(), "", "missing protocol");
-    equal(u+"", "example.org/foo.html", "no-scheme url");
+    equal(u+"", "//example.org/foo.html", "no-scheme url");
 });
 test("username", function() { 
     var u = new URI("http://example.org/foo.html");

--- a/test/urls.js
+++ b/test/urls.js
@@ -302,6 +302,49 @@ var urls = [{
             punycode: false
         }
     }, {
+        name: 'scheme-relative: URL',
+        url: '//example.com/some/directory/file.html?query=string#fragment',
+        parts: {
+            protocol: null,
+            username: null,
+            password: null,
+            hostname: 'example.com',
+            port: null,
+            path: '/some/directory/file.html',
+            query: 'query=string',
+            fragment: 'fragment'
+        },
+        accessors: {
+            protocol: '',
+            username: '',
+            password: '',
+            port: '',
+            path: '/some/directory/file.html',
+            query: 'query=string',
+            fragment: 'fragment',
+            authority: 'example.com',
+            subdomain: '',
+            domain: 'example.com',
+            tld: 'com',
+            directory: '/some/directory',
+            filename: 'file.html',
+            suffix: 'html',
+            hash: '#fragment',
+            search: '?query=string',
+            host: 'example.com',
+            hostname: 'example.com'
+        },
+        is: {
+            relative: false,
+            name: true,
+            sld: false,
+            ip: false,
+            ip4: false,
+            ip6: false,
+            idn: false,
+            punycode: false
+        }
+    }, {
         name: 'missing scheme',
         url: 'user:pass@www.example.org:123/some/directory/file.html?query=string#fragment',
         parts: {
@@ -347,7 +390,7 @@ var urls = [{
     }, {
         name: 'ignoring scheme',
         url: '://user:pass@example.org:123/some/directory/file.html?query=string#fragment',
-        _url: 'user:pass@example.org:123/some/directory/file.html?query=string#fragment',
+        _url: '//user:pass@example.org:123/some/directory/file.html?query=string#fragment',
         parts: {
             protocol: "", // not null
             username: 'user',


### PR DESCRIPTION
Add support for scheme relative URLs like `//example.com/file.html`

Also note that the URL tested here: https://github.com/medialize/URI.js/blob/gh-pages/test/urls.js#L349 is invalid and should throw an error on parsing, or at least consider the whole string as a path.

Example:

//a248.e.akamai.net/assets.github.com/images/modules/header/logov7@4x.png

![Valid relative URL](//a248.e.akamai.net/assets.github.com/images/modules/header/logov7@4x.png)

://a248.e.akamai.net/assets.github.com/images/modules/header/logov7@4x.png

![Invalid URL](://a248.e.akamai.net/assets.github.com/images/modules/header/logov7@4x.png)
