### PR TITLE
Avoid removal of copyright information on minification

### DIFF
--- a/src/IPv6.js
+++ b/src/IPv6.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * URI.js - Mutating URLs
  * IPv6 Support
  *

--- a/src/SecondLevelDomains.js
+++ b/src/SecondLevelDomains.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * URI.js - Mutating URLs
  * Second Level Domain (SLD) Support
  *

--- a/src/URI.js
+++ b/src/URI.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * URI.js - Mutating URLs
  *
  * Version: 1.6.0

--- a/src/jquery.URI.js
+++ b/src/jquery.URI.js
@@ -1,4 +1,4 @@
-/*
+/*!
  * URI.js - Mutating URLs
  * jQuery Plugin
  *


### PR DESCRIPTION
Most JavaScript minifiers strips regular comments, but not "important" block comments.

I believe copyright and license information should always be preserved on minification, and that's why I suggest that those comments should be changed to important.

``` js
/*
  Regular block comment.
 */

/*!
  Important block comment.
 */
```

Thank you for this great library!
