### PR TITLE
Fixes TypeError for domain() when domain reads as blank.

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -863,7 +863,7 @@ p.domain = function(v, build) {
 
         // if hostname consists of 1 or 2 segments, it must be the domain
         var t = this._parts.hostname.match(/\./g);
-        if (t.length < 2) {
+        if (t && t.length < 2) {
             return this._parts.hostname;
         }
 


### PR DESCRIPTION
When calling `url.domain()` or `url.subdomain()` on a URI of the form `http://test/`, a TypeError results. This patch fixes that error.
