### PR TITLE
Don't append query and fragment to URI if they are empty

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -335,11 +335,11 @@ URI.build = function(parts) {
         t += parts.path;
     }
 
-    if (typeof parts.query == "string") {
+    if (typeof parts.query === "string" && '' !== parts.query) {
         t += '?' + parts.query;
     }
 
-    if (typeof parts.fragment === "string") {
+    if (typeof parts.fragment === "string" && '' !== parts.fragment) {
         t += '#' + parts.fragment;
     }
     return t;


### PR DESCRIPTION
Added 2 checks for empty string in the URI.build function.
