### PR TITLE
Passed base to the URI constructor.

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -24,7 +24,7 @@ var _use_module = typeof module !== "undefined" && module.exports,
     URI = function(url, base) {
         // Allow instantiation without the 'new' keyword
         if (!(this instanceof URI)) {
-            return new URI(url);
+            return new URI(url, base);
         }
 
         if (url === undefined) {


### PR DESCRIPTION
Shouldn't the base variable also be passed as an argument?
