### PR TITLE
UglifyJS compressing causes Range Error

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -616,11 +616,8 @@ p.clone = function() {
     return new URI(this);
 };
 
-p.toString = function() {
+p.valueOf = p.toString = function() {
     return this.build(false)._string;
-};
-p.valueOf = function() {
-    return this.toString();
 };
 
 // generate simple accessors


### PR DESCRIPTION
[UglifyJS2](https://github.com/mishoo/UglifyJS2) with compression enabled and default options will see the line

``` javascript
"" + this.toString();
```

and minify it into this line

``` javascript
"" + this
```

and that normally should work, but the `.valueOf()` function then falls into
an infinite loop.  Assigning the same function to both `.toString()` and
`.valueOf()` not only eliminates this problem, but it also shrinks the code an
eensy weensy bit.
