### PR TITLE
Fixed tld() returning wrong

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -1011,6 +1011,10 @@ p.tld = function(v, build) {
         }
 
         var pos = this._parts.hostname.lastIndexOf('.');
+        
+        if (pos === -1) {
+            return "";            
+        }    
         var tld = this._parts.hostname.substring(pos + 1);
 
         if (build !== true && SLD && SLD.list[tld.toLowerCase()]) {


### PR DESCRIPTION
Now:
http://example/ returns `example` from `tld()`

After:
http://example/ returns `(empty string)` from `tld()`

I would prefer returning null but the other checks returns an empty string...
