### PR TITLE
Accept Location object or anchor element representing a filesystem URL as an argument to new URI().

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -820,7 +820,7 @@ p.href = function(href, build) {
     this._parts = URI._parts();
 
     var _URI = href instanceof URI;
-    var _object = typeof href === "object" && (href.hostname || href.path);
+    var _object = typeof href === "object" && (href.hostname || href.path || href.pathname);
 
     
     // window.location is reported to be an object, but it's not the sort

--- a/test/test.js
+++ b/test/test.js
@@ -13,9 +13,22 @@ test("new URI(object)", function() {
     var u = new URI({protocol: "http", hostname: 'example.org'});
     ok(u instanceof URI, "instanceof URI");
     ok(u._parts.hostname !== undefined, "host undefined");
-    
-    u = new URI(location);
+});
+test("new URI(Location)", function () {
+    var u = new URI(location);
     equal(u.href(), String(location.href), "location object");
+});
+test("new URI(HTMLAnchorElement", function (){
+    var a = document.createElement("a");
+    a.href = "http://example.org/foobar.html";
+    var u = new URI(a);
+    equal(u.scheme(), "http", "scheme");
+    equal(u.host(), "example.org", "host");
+    equal(u.path(), "/foobar.html", "path");
+
+    a.href = "file:///C:/foo/bar.html";
+    u = new URI(a);
+    equal(u.href(), a.href, "file");
 });
 test("new URI(URI)", function() {
     var u = new URI(new URI({protocol: "http", hostname: 'example.org'}));
@@ -30,7 +43,8 @@ test("new URI(new Date())", function() {
 test("new URI()", function() {
     var u = new URI();
     ok(u instanceof URI, "instanceof URI");
-    ok(u._parts.hostname === location.hostname, "hostname == location.hostname");
+    ok(u._parts.hostname === location.hostname || u._parts.hostname === null && location.hostname === '',
+            "hostname == location.hostname");
 });
 test("function URI(string)", function() {
     var u = new URI("http://example.org/");


### PR DESCRIPTION
This changeset enables the following when running from the local filesystem (previously it only worked when running from a network resource):

``` javascript
URI(window.location);
```

Equivalently, it enables the following:

``` javascript
var a = document.createElement("a");
a.href = "file:///C:/foo/bar.html";
URI(a);
```

As a side-effect, this changeset fixes the unit tests when running from the local filesystem.

Prior to this change, when running from the local filesystem, tests would fail as follows:
- `constructing: new URI(object)`: `TypeError: invalid input at URI.p.href (URI.js:847:15)`
- `constructing: new URI()`: fail: `hostname == location.hostname`

I’ve also added some new tests to verify the new features.
