### PR TITLE
fix readable()

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -1617,7 +1617,7 @@ p.readable = function() {
         t += '?' + q.substring(1);
     }
 
-    t += uri.hash();
+    t += URI.decodeQuery(uri.hash());
     return t;
 };
 


### PR DESCRIPTION
now the "readable" function is escaping the fragments too
