### PR TITLE
jquery.ui: don't use undefined to build an initial URI

### DIFF
--- a/src/jquery.URI.js
+++ b/src/jquery.URI.js
@@ -152,7 +152,7 @@ $.fn.uri = function(uri) {
         if (uri) {
             return uri;
         } else {
-    		uri = URI($this.attr(property));
+    		uri = URI($this.attr(property) || '');
         }
     }
     


### PR DESCRIPTION
If you call `.attr('src')` on an image that doesn't have a src yet, it momentarily changes the src to `window.location`, which could result in an extra request to `window.location`.
