### PR TITLE
Fix getType() for IE 8

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -59,6 +59,9 @@ function escapeRegEx(string) {
 }
 
 function getType(value) {
+    // required for compatibility with IE 8
+    if (typeof value === 'undefined') { return 'Undefined' }
+
     return String(Object.prototype.toString.call(value)).slice(8, -1);
 }
 


### PR DESCRIPTION
`getType()` was returning `"Object"` when given an `undefined`. This breaks `hasQuery('blub')`. This is an easy fix.
