### PR TITLE
package.json repository field

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,6 +6,11 @@
         "name": "Rodney Rehm",
         "url": "http://rodneyrehm.de"
     },
+    "repository" :
+    {
+        "type" : "git",
+        "url" : "https://github.com/medialize/URI.js.git"
+    },
     "licenses": [
         {
             "type": "MIT",


### PR DESCRIPTION
newer versions of NPM (v1.2.20) complains when there is no repository info in packages you use every time you run `npm install`.

![screen shot 2013-08-07 at 10 58 07](https://f.cloud.github.com/assets/762956/923159/8a2b0f86-ff3f-11e2-92fa-d2a3518e9254.png)
