### PR TITLE
npm installed URIjs 1.11.1 fails to load with `TypeError: Cannot read property 'IPv6' of undefined` 

### DIFF
--- a/src/IPv6.js
+++ b/src/IPv6.js
@@ -36,7 +36,7 @@ console.log(_in, _out, _expected, _out === _expected);
 */
 
 // save current IPv6 variable, if any
-var _IPv6 = root.IPv6;
+var _IPv6 = root && root.IPv6;
 
 function best(address) {
     // based on:

--- a/src/SecondLevelDomains.js
+++ b/src/SecondLevelDomains.js
@@ -29,7 +29,7 @@
 "use strict";
 
 // save current SecondLevelDomains variable, if any
-var _SecondLevelDomains = root.SecondLevelDomains;
+var _SecondLevelDomains = root && root.SecondLevelDomains;
 
 var hasOwn = Object.prototype.hasOwnProperty;
 var SLD = {

--- a/src/URI.js
+++ b/src/URI.js
@@ -27,7 +27,7 @@
 "use strict";
 
 // save current URI variable, if any
-var _URI = root.URI;
+var _URI = root && root.URI;
 
 function URI(url, base) {
     // Allow instantiation without the 'new' keyword


### PR DESCRIPTION
``` console
$ npm install URIjs
npm http GET https://registry.npmjs.org/URIjs
npm http 200 https://registry.npmjs.org/URIjs
npm http GET https://registry.npmjs.org/URIjs/-/URIjs-1.11.1.tgz
npm http 200 https://registry.npmjs.org/URIjs/-/URIjs-1.11.1.tgz
URIjs@1.11.1 node_modules/URIjs
$ node
> require('URIjs')
TypeError: Cannot read property 'IPv6' of undefined
    at ./node_modules/URIjs/src/IPv6.js:39:17
    at _IPv6 (./node_modules/URIjs/src/IPv6.js:19:26)
    at Object.<anonymous> (./node_modules/URIjs/src/IPv6.js:27:2)
    at Module._compile (module.js:456:26)
    at Object.Module._extensions..js (module.js:474:10)
    at Module.load (module.js:356:32)
    at Function.Module._load (module.js:312:12)
    at Module.require (module.js:364:17)
    at require (module.js:380:17)
    at _URI (./submodules/solidstate.js/node_modules/URIjs/src/URI.js:18:57)
```

I haven't totally grokked the packaging of URIjs, or I'd attach some code.

It looks like on https://github.com/medialize/URI.js/blob/gh-pages/src/IPv6.js#L39 that `root` will always be undefined for node, due to https://github.com/medialize/URI.js/blob/gh-pages/src/IPv6.js#L19 calling `factory` with no args. 

It looks like each file assumes `root` exists when generally it doesn't. Am I missing something?
