### PR TITLE
Using indexOf() instead of Regexp()

### DIFF
--- a/src/SecondLevelDomains.js
+++ b/src/SecondLevelDomains.js
@@ -181,31 +181,51 @@ var SLD = {
     // Following methods use lastIndexOf() rather than array.split() in order
     // to avoid any memory allocations.
     has: function(domain) {
-        var tldOffset = domain.lastIndexOf('.');
-        if ( tldOffset <= 0 || tldOffset >= (domain.length-1) ) { return false; }
-        var sldOffset = domain.lastIndexOf('.', tldOffset-1);
-        if ( sldOffset <= 0 || sldOffset >= (tldOffset-1) ) { return false; }
+        var tldOffset = domain.lastIndexOf(".");
+        if (tldOffset <= 0 || tldOffset >= (domain.length-1)) {
+            return false;
+        }
+        var sldOffset = domain.lastIndexOf(".", tldOffset-1);
+        if (sldOffset <= 0 || sldOffset >= (tldOffset-1)) {
+            return false;
+        }
         var sldList = SLD.list[domain.slice(tldOffset+1)];
-        if ( !sldList ) { return false; }
-        return sldList.indexOf(' ' + domain.slice(sldOffset+1, tldOffset) + ' ') >= 0;
+        if (!sldList) {
+            return false;
+        }
+        return sldList.indexOf(" " + domain.slice(sldOffset+1, tldOffset) + " ") >= 0;
     },
     is: function(domain) {
-        var tldOffset = domain.lastIndexOf('.');
-        if ( tldOffset <= 0 || tldOffset >= (domain.length-1) ) { return false; }
-        var sldOffset = domain.lastIndexOf('.', tldOffset-1);
-        if ( sldOffset >= 0 ) { return false; }
+        var tldOffset = domain.lastIndexOf(".");
+        if (tldOffset <= 0 || tldOffset >= (domain.length-1)) {
+            return false;
+        }
+        var sldOffset = domain.lastIndexOf(".", tldOffset-1);
+        if (sldOffset >= 0) {
+            return false;
+        }
         var sldList = SLD.list[domain.slice(tldOffset+1)];
-        if ( !sldList ) { return false; }
-        return sldList.indexOf(' ' + domain.slice(0, tldOffset) + ' ') >= 0;
+        if (!sldList) {
+            return false;
+        }
+        return sldList.indexOf(" " + domain.slice(0, tldOffset) + " ") >= 0;
     },
     get: function(domain) {
-        var tldOffset = domain.lastIndexOf('.');
-        if ( tldOffset <= 0 || tldOffset >= (domain.length-1) ) { return null; }
-        var sldOffset = domain.lastIndexOf('.', tldOffset-1);
-        if ( sldOffset <= 0 || sldOffset >= (tldOffset-1) ) { return null; }
+        var tldOffset = domain.lastIndexOf(".");
+        if (tldOffset <= 0 || tldOffset >= (domain.length-1)) {
+            return null;
+        }
+        var sldOffset = domain.lastIndexOf(".", tldOffset-1);
+        if (sldOffset <= 0 || sldOffset >= (tldOffset-1)) {
+            return null;
+        }
         var sldList = SLD.list[domain.slice(tldOffset+1)];
-        if ( !sldList ) { return null; }
-        if ( sldList.indexOf(' ' + domain.slice(sldOffset+1, tldOffset) + ' ') < 0 ) { return null; }
+        if (!sldList) {
+            return null;
+        }
+        if (sldList.indexOf(" " + domain.slice(sldOffset+1, tldOffset) + " ") < 0) {
+            return null;
+        }
         return domain.slice(sldOffset+1);
     },
     noConflict: function(){

--- a/test/test.js
+++ b/test/test.js
@@ -475,18 +475,15 @@ test("sld", function() {
     var tld, slds, sld, iSld;
     while ( iTld-- ) {
         tld = tlds[iTld];
-        // We trim and split on whitespaces, so if someone mistakenly uses
-        // more than one space to separate the SLD fragments, it will cause
-        // the tests to fail.
         slds = list[tld].trim().split(/\s+/);
         iSld = slds.length;
         while ( iSld-- ) {
-            sld = slds[iSld].trim() + '.' + tld;
+            sld = slds[iSld].trim() + "." + tld;
             u.hostname("www.example." + sld);
             equal(u.is("sld"), true, "is sld");
             equal(u.domain(), "example." + sld, "domain is example." + sld);
             equal(u.subdomain(), "www", "subdomain is www");
-            u.hostname('www.example.' + tld);
+            u.hostname("www.example." + tld);
             equal(u.is("sld"), false, "is not sld");
         }
     }


### PR DESCRIPTION
Performance improvement seen at (along with the intermediate experiments using binary search):
http://jsperf.com/uri-js-sld-regex-vs-binary-search/4

Memory footprint on my 32-bit OS:
Regexp: > 500K
indexOf: < 20K

A test has been added to ensure all SLD are correctly processed by the new code.
