### PR TITLE
Update and rename component.json to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -9,6 +9,17 @@
         "src/URITemplate.js",
         "src/jquery.URI.js"
     ],
+    "ignore": [
+        ".*",
+        "*.css",
+        "*.min.js",
+        "/*.js",
+        "/*.html",
+        "/*.json",
+        "utils",
+        "test",
+        "prettify"
+    ],
     "dependencies": {
         "jquery": ">=1.7.0"
     }


### PR DESCRIPTION
bower renamed its config file to `bower.json` from `component.json`. Adding an
`ignore` property immensely reduces the size of the library on disk.
