### PR TITLE
Remove the minified version of jquery.URI and URI from the Bower JSON

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -8,8 +8,6 @@
     "src/punycode.js",
     "src/URITemplate.js",
     "src/jquery.URI.js",
-    "src/URI.min.js",
-    "src/jquery.URI.min.js",
     "src/URI.fragmentQuery.js",
     "src/URI.fragmentURI.js"
   ],


### PR DESCRIPTION
According to the [Bower Specs](https://github.com/bower/bower.json-spec#main) about Bower JSON File, it's main section should **NOT** include minified files.

Moreover, removing them would not harm at all since non-minified versions are already listed in the main files section.
