### PR TITLE
Add spm support

### DIFF
--- a/package.json
+++ b/package.json
@@ -92,5 +92,8 @@
     "jshint-stylish": "~0.1.5",
     "grunt": "~0.4.2",
     "grunt-contrib-jshint": "~0.8.0"
+  },
+  "spm": {
+    "main": "src/URI.js"
   }
 }


### PR DESCRIPTION
A nicer package manager: http://spmjs.io
Documentation: http://spmjs.io/documentation

http://spmjs.io/package/urijs

---

It is a package manager based on [Sea.js](https://github.com/seajs/seajs) which is a popular module loader in China.

spmjs focus in browser side. We supply a complete lifecycle managment of package by using [spm](https://github.com/spmjs/spm/tree/master).

> If you need ownership of urijs in spmjs, I can add it for your account after signing in http://spmjs.io.
