### PR TITLE
Add license type to bower.json

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -25,5 +25,6 @@
   ],
   "dependencies": {
     "jquery": ">=1.7.0"
-  }
+  },
+  "license": "MIT"
 }


### PR DESCRIPTION
Make the licensing explicit in bower.json.
