### PR TITLE
URI(undefined) now throws type error

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -40,6 +40,10 @@
     }
 
     if (url === undefined) {
+      if (arguments.length) {
+        throw new TypeError('undefined is not a valid argument for URI');
+      }
+
       if (typeof location !== 'undefined') {
         url = location.href + '';
       } else {

--- a/test/test.js
+++ b/test/test.js
@@ -85,6 +85,11 @@
       new URI(new Date());
     }, TypeError, 'Failing unknown input');
   });
+  test('new URI(undefined)', function() {
+    raises(function() {
+      new URI(undefined);
+    }, TypeError, 'Failing undefined input');
+  });
   test('new URI()', function() {
     var u = new URI();
     ok(u instanceof URI, 'instanceof URI');


### PR DESCRIPTION
Note that this differs from URI() which still works as a shortcut for
URI(location).

Since there is no reason to explicitly call URI with undefined, it is
safe to assume that this happens because of user error. URI now
correctly throws a type error with a message explaining that undefined
is not a valid argument.