### PR TITLE
Fix spacing for repository in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -6,10 +6,9 @@
     "name": "Rodney Rehm",
     "url": "http://rodneyrehm.de"
   },
-  "repository" :
-  {
-    "type" : "git",
-    "url" : "https://github.com/medialize/URI.js.git"
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/medialize/URI.js.git"
   },
   "licenses": [
     {


### PR DESCRIPTION
Put the brace on the same line as repository and properly space colons.