### PR TITLE
Fixed bug whereby absoluteTo failed on a root base

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -1863,6 +1863,7 @@
 
     if (resolved.path().charAt(0) !== '/') {
       basedir = base.directory();
+      basedir = basedir ? basedir : base.path().indexOf('/') === 0 ? '/' : '';
       resolved._parts.path = (basedir ? (basedir + '/') : '') + resolved._parts.path;
       resolved.normalizePath();
     }

--- a/test/test.js
+++ b/test/test.js
@@ -1121,6 +1121,16 @@
         base: '/path/to/file?some=query#hash',
         result: '/path/to/relative/path?blubber=1#hash3'
       }, {
+        name: 'path-relative path resolve 2',
+        url: 'tofile',
+        base: '/path/to/file',
+        result: '/path/to/tofile'
+      }, {
+        name: 'path-relative path-root resolve',
+        url: 'tofile',
+        base: '/file',
+        result: '/tofile'
+      }, {
         name: 'path-relative parent path resolve',
         url: '../relative/path?blubber=1#hash3',
         base: '/path/to/file?some=query#hash',


### PR DESCRIPTION
    E.g. URI("tofile").absoluteTo("/file") should return "/tofile" but didn't.
    Added test case