### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,12 +10,7 @@
     "type": "git",
     "url": "https://github.com/medialize/URI.js.git"
   },
-  "licenses": [
-    {
-      "type": "MIT",
-      "url": "http://www.opensource.org/licenses/mit-license"
-    }
-  ],
+  "license": "MIT",
   "description": "URI.js is a Javascript library for working with URLs.",
   "keywords": [
     "uri",


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
http://npm1k.org/