### PR TITLE
sort query string

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -693,7 +693,9 @@
 
     var t = '';
     var unique, key, i, length;
-    for (key in data) {
+    var keys = Object.keys(data).sort();
+    for (var j = 0, keysLength = keys.length; j < keysLength; j++) {
+      key = keys[j];
       if (hasOwn.call(data, key) && key) {
         if (isArray(data[key])) {
           unique = {};


### PR DESCRIPTION
In my project I extensively use URLs as hashes which means that two equal URLs have to have identical string representation:
```javascript
var a = new URI("http://example.org?foo=a&bar=b");
var b = new URI("http://example.org?bar=b&foo=a");
assert(a.equals(b));
assert(a.normalize().toString() == b.normalize().toString());
```
I would be grateful if you could cover other cases where this might be an issue.