### PR TITLE
Fix typo in URI instantiation example

### DIFF
--- a/docs.html
+++ b/docs.html
@@ -192,7 +192,7 @@ var uri = new URI(new URI("http://example.org"));
 // URI parts object
 var uri = new URI({
   protocol: "http",
-  host: "example.org"
+  hostname: "example.org"
 });
 
 // without new keyword


### PR DESCRIPTION
It seems `host` is invalid property when instantiating URI with an object. The URI constructor only checks against `hostname`, not `host`; similarly `host` is not present on the unit tests for the constructor.

NOTE: Originally submitted as PR #240, but that PR pointed at the wrong branch.