### PR TITLE
Adds an origin function

### DIFF
--- a/test/test.js
+++ b/test/test.js
@@ -371,6 +371,14 @@
       u.host('foo\\bar.com');
     }, TypeError, 'Failing backslash detection in host');
   });
+  test('origin', function () {
+    var u = new URI('http://foo.bar/foo.html');
+    equal(u.origin(), 'http://foo.bar', 'invalid origin');
+
+    u.origin('http://bar.foo/bar.html');
+    equal(u.origin(), 'http://bar.foo', 'origin didnt change');
+    equal(u+'', 'http://bar.foo/foo.html', 'origin path changed');
+  });
   test('authority', function() {
     var u = new URI('http://foo.bar/foo.html');
 


### PR DESCRIPTION
The origin consists of only the scheme and authority. This change adds the following ways to work with the origin:
```
URI.buildOrigin(parts);
u.origin()
u.origin(uri)
```