### PR TITLE
Fix Issue #264: Handle a few dot segment normalization corner cases better

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -1817,6 +1817,8 @@
       return this;
     }
 
+    _path = URI.recodePath(_path);
+
     var _was_relative;
     var _leadingParents = '';
     var _parent, _pos;
@@ -1847,7 +1849,7 @@
 
     // resolve parents
     while (true) {
-      _parent = _path.indexOf('/..');
+      _parent = _path.search(/\/\.\.(\/|$)/);
       if (_parent === -1) {
         // no more ../ to resolve
         break;
@@ -1869,7 +1871,6 @@
       _path = _leadingParents + _path.substring(1);
     }
 
-    _path = URI.recodePath(_path);
     this._parts.path = _path;
     this.build(!build);
     return this;

--- a/test/test.js
+++ b/test/test.js
@@ -1167,6 +1167,22 @@
     u = URI('/foo/..').normalizePath();
     equal(u.path(), '/', 'root /foo/..');
 
+    u = URI('/foo/.bar').normalizePath();
+    equal(u.path(), '/foo/.bar', 'root /foo/.bar');
+
+    u = URI('/foo/..bar').normalizePath();
+    equal(u.path(), '/foo/..bar', 'root /foo/..bar');
+
+    // Percent Encoding normalization has to happen before dot segment normalization
+    u = URI('/foo/%2E%2E').normalizePath();
+    equal(u.path(), '/', 'root /foo/%2E%2E');
+
+    u = URI('/foo/%2E').normalizePath();
+    equal(u.path(), '/foo/', 'root /foo/%2E');
+
+    u = URI('/foo/%2E%2E%2Fbar').normalizePath();
+    equal(u.path(), '/foo/..%2Fbar', 'root /foo/%2E%2E%2Fbar');
+
     u = URI('../../../../../www/common/js/app/../../../../www_test/common/js/app/views/view-test.html');
     u.normalize();
     equal(u.path(), '../../../../../www_test/common/js/app/views/view-test.html', 'parent relative');


### PR DESCRIPTION
See Issue #264 

There are a few normalization steps that URI parsers may perform,
one is dot segment normalization and another is percent encoding
normalization.

The spec isn't clear on what order you should apply them, but in
practice browsers seem to normalize percent encoding, then remove
dot segments.

That means that `/foo/%2E%2E/bar` == `/bar`

Also, `/foo/..bar` should not have the dot segment removed.