### PR TITLE
Allow periods in the variable name

### DIFF
--- a/src/URITemplate.js
+++ b/src/URITemplate.js
@@ -133,9 +133,9 @@
   // pattern to identify expressions [operator, variable-list] in template
   URITemplate.EXPRESSION_PATTERN = /\{([^a-zA-Z0-9%_]?)([^\}]+)(\}|$)/g;
   // pattern to identify variables [name, explode, maxlength] in variable-list
-  URITemplate.VARIABLE_PATTERN = /^([^*:]+)((\*)|:(\d+))?$/;
+  URITemplate.VARIABLE_PATTERN = /^([^*:.](?:\.?[^*:.])*)((\*)|:(\d+))?$/;
   // pattern to verify variable name integrity
-  URITemplate.VARIABLE_NAME_PATTERN = /[^a-zA-Z0-9%_]/;
+  URITemplate.VARIABLE_NAME_PATTERN = /[^a-zA-Z0-9%_.]/;
 
   // expand parsed expression (expression, not template!)
   URITemplate.expand = function(expression, data) {

--- a/test/test_template.js
+++ b/test/test_template.js
@@ -387,4 +387,12 @@
     window.URITemplate = actual_lib;
   });
 
+  test('Periods in varnames', function() {
+    var template = new URITemplate('{hello.world.var}');
+    var literal = 'replacement'
+    var data = {'hello.world.var': literal};
+    var expansion = template.expand(data);
+    equal(expansion, literal, 'period in varname');
+  });
+
 })();


### PR DESCRIPTION
From https://tools.ietf.org/html/rfc6570#section-2.3 :
```
variable-list =  varspec *( "," varspec )
varspec       =  varname [ modifier-level4 ]
varname       =  varchar *( ["."] varchar )
varchar       =  ALPHA / DIGIT / "_" / pct-encoded
```