### PR TITLE
Disallow invalid literals

### DIFF
--- a/test/test_template.js
+++ b/test/test_template.js
@@ -395,4 +395,10 @@
     equal(expansion, literal, 'period in varname');
   });
 
+  test('Invalid literals', function () {
+    raises(function() {
+      URITemplate('invalid.char}acter').parse();
+    }, Error, 'Failing invalid literal');
+  });
+
 })();


### PR DESCRIPTION
Hey there, here's another spec adherence proposal. 

It seems that the parts of the template which are supposed to be copied over (literals) are not allowed to have a character in a specific set of disallowed characters.

This change throws an error during the parse if it finds one of these characters in a literal string.

From https://tools.ietf.org/html/rfc6570#section-2.1 :
```
     literals      =  %x21 / %x23-24 / %x26 / %x28-3B / %x3D / %x3F-5B
                   /  %x5D / %x5F / %x61-7A / %x7E / ucschar / iprivate
                   /  pct-encoded
                        ; any Unicode character except: CTL, SP,
                        ;  DQUOTE, "'", "%" (aside from pct-encoded),
                        ;  "<", ">", "\", "^", "`", "{", "|", "}"
```
And later, in the [Appendix](https://tools.ietf.org/html/rfc6570#appendix-A) :
```
   Scan the template and copy literals to the result string (as in
   Section 3.1) until an expression is indicated by a "{", an error is
   indicated by the presence of a non-literals character other than "{",
   or the template ends.  When it ends, return the result string and its
   current error or non-error state.
```