### PR TITLE
Disallow prefix modifier on variables with composite values

### DIFF
--- a/src/URITemplate.js
+++ b/src/URITemplate.js
@@ -162,6 +162,11 @@
         continue;
       }
 
+      if (d.type > 1 && variable.maxlength) {
+        // composite variable cannot specify maxlength
+        throw new Error('Invalid expression: Prefix modifier not applicable to variable "' + variable.name + '"');
+      }
+
       // expand the given variable
       buffer.push(URITemplate['expand' + type](
         d,

--- a/test/test_template.js
+++ b/test/test_template.js
@@ -376,6 +376,13 @@
     }, Error, 'Failing invalid modifier');
   });
 
+  test('Expansion errors', function() {
+    raises(function() {
+      var data = {'composite_var': ['multiple', 'values']};
+      URITemplate('{composite_var:3}').expand(data);
+    }, Error, 'Failing prefix modifier after composite variable');
+  });
+
   test('noConflict mode', function() {
     var actual_lib = URITemplate; // actual library; after loading, before noConflict()
     var unconflicted = URITemplate.noConflict();


### PR DESCRIPTION
One last proposal. This one is pretty explicit in the spec.

From https://tools.ietf.org/html/rfc6570#section-2.4.1 :
```
   A prefix modifier indicates that the variable expansion is limited to
   a prefix of the variable's value string.  Prefix modifiers are often
   used to partition an identifier space hierarchically, as is common in
   reference indices and hash-based storage.  It also serves to limit
   the expanded value to a maximum number of characters.  Prefix
   modifiers are not applicable to variables that have composite values.
```