### PR TITLE
Add CDNJS version badge in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 # URI.js #
 
+[![CDNJS](https://img.shields.io/cdnjs/v/URI.js.svg)](https://cdnjs.com/libraries/URI.js)
 * [About](http://medialize.github.io/URI.js/)
 * [Understanding URIs](http://medialize.github.io/URI.js/about-uris.html)
 * [Documentation](http://medialize.github.io/URI.js/docs.html)


### PR DESCRIPTION
This will add the badge to show its version on CDNJS and also link to its page on CDNJS!