### PR TITLE
Allow single quote characters in literals

### DIFF
--- a/src/URITemplate.js
+++ b/src/URITemplate.js
@@ -137,7 +137,7 @@
   // pattern to verify variable name integrity
   URITemplate.VARIABLE_NAME_PATTERN = /[^a-zA-Z0-9%_.]/;
   // pattern to verify literal integrity
-  URITemplate.LITERAL_PATTERN = /[<>{}'"`^| \\]/;
+  URITemplate.LITERAL_PATTERN = /[<>{}"`^| \\]/;
 
   // expand parsed expression (expression, not template!)
   URITemplate.expand = function(expression, data) {


### PR DESCRIPTION
Single quotes are valid characters in uris, so we do not want to break users of this library who may have single quotes in their templates.

See https://github.com/medialize/URI.js/pull/289#issuecomment-278099829