### PR TITLE
Add a strict mode option to URITemplate#expand.

### DIFF
--- a/src/URITemplate.js
+++ b/src/URITemplate.js
@@ -140,7 +140,7 @@
   URITemplate.LITERAL_PATTERN = /[<>{}"`^| \\]/;
 
   // expand parsed expression (expression, not template!)
-  URITemplate.expand = function(expression, data) {
+  URITemplate.expand = function(expression, data, opts) {
     // container for defined options for the given operator
     var options = operators[expression.operator];
     // expansion type (include keys or not)
@@ -154,6 +154,9 @@
     for (i = 0; (variable = variables[i]); i++) {
       // fetch simplified data source
       d = data.get(variable.name);
+      if (d.type === 0 && opts && opts.strict) {
+          throw new Error('Missing expansion value for variable "' + variable.name + '"');
+      }
       if (!d.val.length) {
         if (d.type) {
           // empty variables (empty string)
@@ -320,7 +323,7 @@
   };
 
   // expand template through given data map
-  p.expand = function(data) {
+  p.expand = function(data, opts) {
     var result = '';
 
     if (!this.parts || !this.parts.length) {
@@ -340,7 +343,7 @@
         // literal string
         ? this.parts[i]
         // expression
-        : URITemplate.expand(this.parts[i], data);
+        : URITemplate.expand(this.parts[i], data, opts);
       /*jshint laxbreak: false */
     }
 

--- a/test/test_template.js
+++ b/test/test_template.js
@@ -408,4 +408,10 @@
     }, Error, 'Failing invalid literal');
   });
 
+  test('Strict mode', function () {
+    raises(function() {
+        new URITemplate("/{foo}/bar").expand({ foobar: 123 }, { strict: true });
+    }, Error, 'Missing expansion value for variable in strict mode.');
+  });
+
 })();

--- a/uri-template.html
+++ b/uri-template.html
@@ -107,6 +107,11 @@ template.expand(function(key) {
 template.expand({file : function(key) {
     return "hello world.html";
 }});
+
+// Using strict mode
+var template = new URITemplate("http://example.org/{file}");
+var result = template.expand({filename: "hello world.html"}, { strict: true });
+// Uncaught Error: Missing expansion value for variable "file"
 </pre>
     
     


### PR DESCRIPTION
When activated, strict mode makes URITemplate throw instead of
silently replacing missing values by empty strings.