### PR TITLE
Make constructor throw on invalid ports.

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -1040,25 +1040,17 @@
     }
   };
 
-  URI.ensureValidPort = function(v) {
-    var valid = false;
-
-    if (!v || !v.length) {
-      // no custom port specified
-      valid = true;
-    } else {
-      var port = Number(v);
-
-      // verify type and range
-      if (Number.isInteger(port) && (port > 0) && (port < 65536)
-      ) {
-        valid = true;
-      }
+  URI.ensureValidPort = function (v) {
+    if (!v) {
+      return;
     }
 
-    if (!valid) {
-      throw new TypeError('Port "' + v + '" is not a valid port');
+    var port = Number(v);
+    if (Number.isInteger(port) && (port > 0) && (port < 65536)) {
+      return;
     }
+
+    throw new TypeError('Port "' + v + '" is not a valid port');
   };
 
   URI.basicValidation = function(parts) {

--- a/src/URI.js
+++ b/src/URI.js
@@ -1464,6 +1464,10 @@
         v += '.';
       }
 
+      if (v.indexOf(':') !== -1) {
+        throw new TypeError('Domains cannot contain colons');
+      }
+
       if (v) {
         URI.ensureValidHostname(v);
       }
@@ -1502,6 +1506,10 @@
     } else {
       if (!v) {
         throw new TypeError('cannot set domain empty');
+      }
+
+      if (v.indexOf(':') !== -1) {
+        throw new TypeError('Domains cannot contain colons');
       }
 
       URI.ensureValidHostname(v);

--- a/src/URI.js
+++ b/src/URI.js
@@ -575,6 +575,10 @@
       string = '/' + string;
     }
 
+    if (parts.port) {
+      URI.ensureValidPort(parts.port);
+    }
+
     return string.substring(pos) || '/';
   };
   URI.parseAuthority = function(string, parts) {
@@ -1031,6 +1035,27 @@
     }
   };
 
+  URI.ensureValidPort = function(v) {
+    var valid = false;
+
+    if (!v || !v.length) {
+      // no custom port specified
+      valid = true;
+    } else {
+      var port = Number(v);
+
+      // verify type and range
+      if (Number.isInteger(port) && (port > 0) && (port < 65536)
+      ) {
+        valid = true;
+      }
+    }
+
+    if (!valid) {
+      throw new TypeError('Port "' + v + '" is not a valid port');
+    }
+  };
+
   // noConflict
   URI.noConflict = function(removeAll) {
     if (removeAll) {
@@ -1288,9 +1313,7 @@
           v = v.substring(1);
         }
 
-        if (v.match(/[^0-9]/)) {
-          throw new TypeError('Port "' + v + '" contains characters other than [0-9]');
-        }
+        URI.ensureValidPort(v);
       }
     }
     return _port.call(this, v, build);

--- a/test/test.js
+++ b/test/test.js
@@ -124,6 +124,21 @@
     ok(u instanceof URI, 'instanceof URI');
     ok(u._parts.hostname !== undefined, 'host undefined');
   });
+  test('function URI(string) with invalid port "port" throws', function () {
+    raises(function () {
+      new URI('http://example.org:port');
+    }, TypeError, "throws TypeError");
+  });
+  test('function URI(string) with invalid port "0" throws', function () {
+    raises(function () {
+      new URI('http://example.org:0');
+    }, TypeError, "throws TypeError");
+  });
+  test('function URI(string) with invalid port "65536" throws', function () {
+    raises(function () {
+      new URI('http://example.org:65536');
+    }, TypeError, "throws TypeError");
+  });
   test('new URI(string, string)', function() {
     // see http://dvcs.w3.org/hg/url/raw-file/tip/Overview.html#constructor
     var u = new URI('../foobar.html', 'http://example.org/hello/world.html');

--- a/test/test.js
+++ b/test/test.js
@@ -139,6 +139,11 @@
       new URI('http://example.org:65536');
     }, TypeError, "throws TypeError");
   });
+  test('function URI(string) with protocol and without hostname should throw', function () {
+    raises(function () {
+      new URI('http://');
+    }, TypeError, "throws TypeError");
+  });
   test('new URI(string, string)', function() {
     // see http://dvcs.w3.org/hg/url/raw-file/tip/Overview.html#constructor
     var u = new URI('../foobar.html', 'http://example.org/hello/world.html');
@@ -1353,11 +1358,6 @@
         url: 'file:///C:/skyclan/snipkit',
         base: 'http://example.com/foo/bar',
         result: 'file:///C:/skyclan/snipkit'
-      }, {
-        name: 'absolute passthru - generic empty-hostname - urljoin (#328)',
-        url: 'http:///foo',
-        base: 'http://example.com/foo/bar',
-        result: 'http:///foo'
       }, {
         name: 'file paths - urljoin',
         url: 'anotherFile',

--- a/test/test.js
+++ b/test/test.js
@@ -243,13 +243,16 @@
     equal(u.hostname(), 'abc.foobar.lala', 'hostname changed');
     equal(u+'', 'http://abc.foobar.lala/foo.html', 'hostname changed url');
 
-    u.hostname('');
-    equal(u.hostname(), '', 'hostname removed');
-    equal(u+'', 'http:///foo.html', 'hostname removed url');
-
     raises(function() {
       u.hostname('foo\\bar.com');
     }, TypeError, 'Failing backslash detection in hostname');
+
+    raises(function() {
+      u.hostname('');
+    }, TypeError, "Trying to set an empty hostname with http(s) protocol throws a TypeError");
+    raises(function() {
+      u.hostname(null);
+    }, TypeError, "Trying to set hostname to null with http(s) protocol throws a TypeError");
   });
   test('port', function() {
     var u = new URI('http://example.org/foo.html');


### PR DESCRIPTION
This makes the behaviour consistent with port().

Fixes #344 