### PR TITLE
Feature/to uri

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -487,6 +487,31 @@
 
   URI.encodeReserved = generateAccessor('reserved', 'encode');
 
+  URI.toUri = function(string, scheme = '//') {
+    /**
+     * Convert a string which may or may not have a valid scheme
+     * to a valid URI prepending a scheme if needed
+     * @param {string} string The url to parse
+     * @param {string} scheme The scheme to use. One of [//, https, http]
+     * @return
+     *
+     */
+    // if the uri doesn't have a scheme, add one
+    // now so it doesn't get parsed as a path
+    if (!string.match(/^(https|http)?:\/\//i)) {
+      // add the given scheme if its a valid one
+      switch (true) {
+        case scheme === 'http':
+        case scheme === 'https':
+          scheme = scheme+':';
+          break;
+        default:
+          scheme = '';
+      }
+      string = scheme+'//'+string;
+    }
+    return URI.build(URI.parse(string));
+  };
   URI.parse = function(string, parts) {
     var pos;
     if (!parts) {

--- a/src/URI.js
+++ b/src/URI.js
@@ -487,28 +487,31 @@
 
   URI.encodeReserved = generateAccessor('reserved', 'encode');
 
-  URI.toUri = function(string, scheme = '//') {
+  URI.toUri = function(string, defaults) {
     /**
      * Convert a string which may or may not have a valid scheme
      * to a valid URI prepending a scheme if needed
      * @param {string} string The url to parse
      * @param {string} scheme The scheme to use. One of [//, https, http]
-     * @return
+     * @return {string} A valid URI
      *
      */
+    defaults = defaults || {};
     // if the uri doesn't have a scheme, add one
     // now so it doesn't get parsed as a path
     if (!string.match(/^(https|http)?:\/\//i)) {
       // add the given scheme if its a valid one
       switch (true) {
-        case scheme === 'http':
-        case scheme === 'https':
-          scheme = scheme+':';
+        case defaults.scheme === 'http':
+        case defaults.scheme === 'https':
+          defaults.scheme = defaults.scheme+':';
           break;
         default:
-          scheme = '';
+          defaults.scheme = '';
       }
-      string = scheme+'//'+string;
+      // make sure we always have at least // or it'll
+      // be parsed as a path
+      string = defaults.scheme+'//'+string;
     }
     return URI.build(URI.parse(string));
   };


### PR DESCRIPTION
When initializing with a string that is missing the protocol, like `URI('somesite.com');`, the string is parsed as a path and not a URI.

Because of this, `domain(), host(), and port()` do not function as expected and return "";

See https://jsfiddle.net/Ln9c0jpy/1/

Related issues:
https://github.com/medialize/URI.js/issues/260
https://github.com/medialize/URI.js/issues/232
https://github.com/medialize/URI.js/issues/187

This change adds a `toUri` method that allows the user to do this:

`let uri = new URI(URI.toUri('somesite.com', {scheme: 'http'}));`

after which, `uri.domain()` will return the expected `somesite.com`
