### PR TITLE
docs: Fix simple typo, renamce -> rename

### DIFF
--- a/src/URI.js
+++ b/src/URI.js
@@ -26,7 +26,7 @@
 }(this, function (punycode, IPv6, SLD, root) {
   'use strict';
   /*global location, escape, unescape */
-  // FIXME: v2.0.0 renamce non-camelCase properties to uppercase
+  // FIXME: v2.0.0 rename non-camelCase properties to uppercase
   /*jshint camelcase: false */
 
   // save current URI variable, if any

--- a/src/URITemplate.js
+++ b/src/URITemplate.js
@@ -26,7 +26,7 @@
   }
 }(this, function (URI, root) {
   'use strict';
-  // FIXME: v2.0.0 renamce non-camelCase properties to uppercase
+  // FIXME: v2.0.0 rename non-camelCase properties to uppercase
   /*jshint camelcase: false */
 
   // save current URITemplate variable, if any

--- a/src/jquery.URI.js
+++ b/src/jquery.URI.js
@@ -26,7 +26,7 @@
   }
 }(this, function ($, URI) {
   'use strict';
-  // FIXME: v2.0.0 renamce non-camelCase properties to uppercase
+  // FIXME: v2.0.0 rename non-camelCase properties to uppercase
   /*jshint camelcase: false */
 
   var comparable = {};

--- a/test/pre_libs.js
+++ b/test/pre_libs.js
@@ -1,5 +1,5 @@
 /*global window */
-// FIXME: v2.0.0 renamce non-camelCase properties to uppercase
+// FIXME: v2.0.0 rename non-camelCase properties to uppercase
 /*jshint camelcase: false */
 window.URI                = window.URI_pre_lib                = 'original URI, before loading URI.js library';
 window.URITemplate        = window.URITemplate_pre_lib        = 'original URITemplate, before loading URI.js library';

--- a/test/test.js
+++ b/test/test.js
@@ -1,7 +1,7 @@
 (function() {
   'use strict';
   /*global window, document, location, URI, URI_pre_lib, IPv6, IPv6_pre_lib, URITemplate, URITemplate_pre_lib, SecondLevelDomains, SecondLevelDomains_pre_lib, urls, test, ok, equal, strictEqual, deepEqual, raises */
-  // FIXME: v2.0.0 renamce non-camelCase properties to uppercase
+  // FIXME: v2.0.0 rename non-camelCase properties to uppercase
   /*jshint camelcase: false, loopfunc: true */
 
   test('loaded', function() {

--- a/test/test_template.js
+++ b/test/test_template.js
@@ -1,7 +1,7 @@
 (function() {
   'use strict';
   /*global window, URITemplate, URITemplate_pre_lib, test, equal, strictEqual, raises */
-  // FIXME: v2.0.0 renamce non-camelCase properties to uppercase
+  // FIXME: v2.0.0 rename non-camelCase properties to uppercase
   /*jshint camelcase: false, loopfunc: true, newcap: false */
 
   var levels = {


### PR DESCRIPTION
There is a small typo in src/URI.js, src/URITemplate.js, src/jquery.URI.js, test/pre_libs.js, test/test.js, test/test_template.js.

Should read `rename` rather than `renamce`.

